### PR TITLE
#13 Fixed available seniority levels

### DIFF
--- a/TakeLeave.Business/Interfaces/IPositionService.cs
+++ b/TakeLeave.Business/Interfaces/IPositionService.cs
@@ -11,5 +11,6 @@ namespace TakeLeave.Business.Interfaces
         void CreatePosition(PositionDTO positionDTO);
         PositionDTO GetPosition(string title, Models.SeniorityLevel seniorityLevel);
         void UpdatePosition(PositionDTO positionDTO);
+        HashSet<string> GetSeniorityLevelsForSpecifiedTitle(string title);
     }
 }

--- a/TakeLeave.Business/Services/PositionService.cs
+++ b/TakeLeave.Business/Services/PositionService.cs
@@ -125,5 +125,15 @@ namespace TakeLeave.Business.Services
                 _positionRepository.Save();
             }
         }
+
+        public HashSet<string> GetSeniorityLevelsForSpecifiedTitle(string title)
+        {
+            HashSet<string> seniorityLevels = _positionRepository
+                .GetByCondition(position => position.Title.Equals(title))
+                .Select(position => position.SeniorityLevel.ToString())
+                .ToHashSet();
+
+            return seniorityLevels;
+        }
     }
 }

--- a/TakeLeave.Data/Database/Employees/Employee.cs
+++ b/TakeLeave.Data/Database/Employees/Employee.cs
@@ -25,7 +25,6 @@ namespace TakeLeave.Data.Database.Employees
         public DateTime? EmploymentEndDate { get; set; }
         public DateTime InsertDate { get; set; }
         public DateTime? DeleteDate { get; set; }
-        public bool IsAdmin { get; set; }
 
 
         public int DaysOffID { get; set; }

--- a/TakeLeave.Data/Migrations/20240608180049_isAdminPropertyRemovedFromEmployee.Designer.cs
+++ b/TakeLeave.Data/Migrations/20240608180049_isAdminPropertyRemovedFromEmployee.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TakeLeave.Data;
 
@@ -11,9 +12,11 @@ using TakeLeave.Data;
 namespace TakeLeave.Data.Migrations
 {
     [DbContext(typeof(TakeLeaveDbContext))]
-    partial class TakeLeaveDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240608180049_isAdminPropertyRemovedFromEmployee")]
+    partial class isAdminPropertyRemovedFromEmployee
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TakeLeave.Data/Migrations/20240608180049_isAdminPropertyRemovedFromEmployee.cs
+++ b/TakeLeave.Data/Migrations/20240608180049_isAdminPropertyRemovedFromEmployee.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TakeLeave.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class isAdminPropertyRemovedFromEmployee : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                table: "Employees");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                table: "Employees",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/TakeLeave.Web/Areas/HR/Controllers/PositionsController.cs
+++ b/TakeLeave.Web/Areas/HR/Controllers/PositionsController.cs
@@ -93,5 +93,12 @@ namespace TakeLeave.Web.Areas.HR.Controllers
 
             return RedirectToAction(nameof(PositionsList));
         }
+
+        public IActionResult GetSeniorityLevelsForSpecifiedTitle(string title)
+        {
+            HashSet<string> seniorityLevels = _positionService.GetSeniorityLevelsForSpecifiedTitle(title);
+
+            return Json(seniorityLevels);
+        }
     }
 }

--- a/TakeLeave.Web/Areas/HR/Views/Employees/Partial/EmployeeForm.cshtml
+++ b/TakeLeave.Web/Areas/HR/Views/Employees/Partial/EmployeeForm.cshtml
@@ -56,14 +56,18 @@
             <div class="row mb-3">
                 <div class="col">
                     <label asp-for="@Model.PositionTitlesAndSeniorityLevels.Item1" class="control-label">Position:</label>
-                    <select asp-for="@Model.Position.Title" class="form-control"
+                    <select class="form-control"
+                            id="position-title"
+                            asp-for="@Model.Position.Title"
                             asp-items="@(new SelectList(Model.PositionTitlesAndSeniorityLevels.Item1))">
                         <option value="">Select title:</option>
                     </select>
                 </div>
                 <div class="col">
                     <label asp-for="@Model.PositionTitlesAndSeniorityLevels.Item2" class="control-label">Seniority:</label>
-                    <select asp-for="@Model.Position.SeniorityLevel" class="form-control"
+                    <select class="form-control"
+                            id="seniority-level"
+                            asp-for="@Model.Position.SeniorityLevel"
                             asp-items="@(new SelectList(Model.PositionTitlesAndSeniorityLevels.Item2))">
                         <option value="">Select level:</option>
                     </select>

--- a/TakeLeave.Web/Areas/HR/Views/Shared/_Layout.cshtml
+++ b/TakeLeave.Web/Areas/HR/Views/Shared/_Layout.cshtml
@@ -72,6 +72,7 @@
     <script src="~/js/signalr/dist/browser/signalr.js"></script>
     <script src="~/js/chat.js" asp-append-version="true"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/position.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/TakeLeave.Web/wwwroot/js/position.js
+++ b/TakeLeave.Web/wwwroot/js/position.js
@@ -1,0 +1,20 @@
+﻿$("#position-title").on('change', function () {
+    var title = $(this).val();
+    if (title) {
+        var url = `/HR/Positions/GetSeniorityLevelsForSpecifiedTitle?title=${title}`;
+        $.get(url, function (data) {
+            var seniorityLevelsDropdown = $("#seniority-level");
+            seniorityLevelsDropdown.empty();
+            seniorityLevelsDropdown.append('<option value="">Select level:</option>');
+            $.each(data, function (index, item) {
+                seniorityLevelsDropdown.append(
+                    `<option value="${item}">${item}</option>`
+                );
+            });
+        });
+    }
+    else {
+        console.error('Error fetching seniority levels:', error);
+        $('#seniority-level').append('<option value="">Select level:</option>');
+    }
+});


### PR DESCRIPTION
- On employee create/update, based on selected position title, available seniority levels are shown in dropdown. 
  Demo: 
![levels](https://github.com/mkkate/TakeLeave/assets/64722779/53abd5f8-3634-4ca2-be5e-61b2ed17275d)

- unnecessary 'isAdmin' property removed from 'Employee' entity, since role is assigned to each position at create step.